### PR TITLE
Fix for Latest Iridium Skyblock API Changes

### DIFF
--- a/TempFly/pom.xml
+++ b/TempFly/pom.xml
@@ -68,7 +68,12 @@
 		<name>MVdW Public Repositories</name>
 		<url>http://repo.mvdw-software.be/content/groups/public/</url>
 	</repository>
-
+	  
+	<!-- IridiumSkyblock -->
+	<repository>
+	  <id>savagelabs</id>
+	  <url>https://nexus.savagelabs.net/repository/maven-releases/</url>
+        </repository>
   </repositories>
 
   <dependencies>
@@ -114,14 +119,20 @@
 		<version>2.9.2</version>
 		<scope>provided</scope>
 	</dependency>
-	
-    <dependency>
-        <groupId>com.sk89q.worldguard</groupId>
-    	<artifactId>worldguard-bukkit</artifactId>
-        <version>7.0.0</version>
-        <scope>provided</scope>
-    </dependency>
-
+	  
+        <dependency>
+                <groupId>com.sk89q.worldguard</groupId>
+    	        <artifactId>worldguard-bukkit</artifactId>
+                <version>7.0.0</version>
+                <scope>provided</scope>
+        </dependency>
+	  
+	<dependency>
+	         <groupId>com.iridium</groupId>
+	         <artifactId>IridiumSkyblock</artifactId>
+	         <version>2.6.5</version>
+	         <scope>provided</scope>
+	 </dependency>
     
   </dependencies>
 </project>

--- a/TempFly/src/com/moneybags/tempfly/hook/skyblock/plugins/IridiumHook.java
+++ b/TempFly/src/com/moneybags/tempfly/hook/skyblock/plugins/IridiumHook.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.iridium.iridiumskyblock.managers.IslandManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
@@ -18,7 +19,6 @@ import org.bukkit.inventory.ItemStack;
 
 import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.Island;
-import com.iridium.iridiumskyblock.IslandManager;
 import com.iridium.iridiumskyblock.User;
 import com.moneybags.tempfly.TempFly;
 import com.moneybags.tempfly.hook.skyblock.IslandWrapper;
@@ -107,7 +107,8 @@ public class IridiumHook extends SkyblockHook implements Listener {
 	public Player[] getOnlineMembers(IslandWrapper island) {
 		List<Player> online = new ArrayList<>();
 		Island rawIsland = (Island) island.getRawIsland();
-		for (String s: rawIsland.getMembers()) {
+
+		for (String s: rawIsland.members) {
 			Player p = Bukkit.getPlayer(UUID.fromString(s));
 			if (p != null && p.isOnline()) {
 				online.add(p);
@@ -119,8 +120,9 @@ public class IridiumHook extends SkyblockHook implements Listener {
 	@Override
 	public UUID[] getIslandMembers(IslandWrapper island) {
 		List<UUID> ids = new ArrayList<>();
-		Island rawIsland = (Island) island.getRawIsland();
-		for (String s: rawIsland.getMembers()) {
+		Island raw = (Island) island.getRawIsland();
+		Island rawIsland = IslandManager.getIslandViaLocation(raw.center);
+		for (String s: rawIsland.members) {
 			ids.add(UUID.fromString(s));
 		}
 		return ids.toArray(new UUID[ids.size()]);
@@ -131,7 +133,7 @@ public class IridiumHook extends SkyblockHook implements Listener {
 		OfflinePlayer p = Bukkit.getOfflinePlayer(u);
 		User user = User.getUser(p);
 		Island rawIsland = user.getIsland();
-		if (rawIsland == null || !rawIsland.getOwner().equals(u.toString())) {
+		if (rawIsland == null || !rawIsland.owner.equals(u.toString())) {
 			return null;
 		}
 		return getIslandWrapper(rawIsland);
@@ -150,8 +152,7 @@ public class IridiumHook extends SkyblockHook implements Listener {
 
 	@Override
 	public IslandWrapper getIslandAt(Location loc) {
-		IslandManager islandManager;
-		return getIslandWrapper((islandManager = IridiumSkyblock.getIslandManager()) == null ? null : islandManager.getIslandViaLocation(loc));
+		return getIslandWrapper(IslandManager.getIslandViaLocation(loc));
 	}
 
 	@Override
@@ -193,7 +194,7 @@ public class IridiumHook extends SkyblockHook implements Listener {
 		Island rawIsland = (Island) island.getRawIsland();
 		IslandWrapper playerIsland = getTeamIsland(u);
 		if (playerIsland != null) {
-			if (rawIsland.getCoop().contains(((Island)rawIsland).getId())) {
+			if (rawIsland.getCoop().contains(((Island)rawIsland).id)) {
 				return "COOP";
 			}
 		}
@@ -207,7 +208,7 @@ public class IridiumHook extends SkyblockHook implements Listener {
 
 	@Override
 	public UUID getIslandOwner(IslandWrapper island) {
-		return UUID.fromString(((Island)island.getRawIsland()).getOwner());
+		return UUID.fromString(((Island)island.getRawIsland()).owner);
 	}
 
 	/**
@@ -218,29 +219,29 @@ public class IridiumHook extends SkyblockHook implements Listener {
 		if (rawIsland instanceof IslandWrapper) {
 			rawIsland = ((IslandWrapper) rawIsland).getRawIsland();
 		}
-		return String.valueOf(((Island)rawIsland).getId());
+		return String.valueOf(((Island)rawIsland).id);
 	}
 	
 	@Override
 	public IslandWrapper getIslandFromIdentifier(String identifier) {
-		return getIslandWrapper(IridiumSkyblock.getIslandManager().getIslandViaId(Integer.valueOf(identifier)));
+		return getIslandWrapper(IslandManager.getIslandViaId(Integer.valueOf(identifier)));
 	}
 	
 
 	@Override
 	public boolean isIslandMember(UUID u, IslandWrapper island) {
-		return ((Island)island.getRawIsland()).getMembers().contains(u.toString());
+		return ((Island)island.getRawIsland()).members.contains(u.toString());
 	}
 
 	@Override
 	public double getIslandLevel(UUID u) {
 		IslandWrapper island = getTeamIsland(u);
-		return island == null ? 0 : ((Island)island.getRawIsland()).getValue();
+		return island == null ? 0 : ((Island)island.getRawIsland()).value;
 	}
 
 	@Override
 	public double getIslandLevel(IslandWrapper island) {
-		return ((Island)island.getRawIsland()).getValue();
+		return ((Island)island.getRawIsland()).value;
 	}
 
 	@Override
@@ -256,7 +257,7 @@ public class IridiumHook extends SkyblockHook implements Listener {
 	@Override
 	public boolean isIslandWorld(Location loc) {
 		// Try catches a benign error when using /reload because iridium isnt ready yet.
-		try {return IridiumSkyblock.getIslandManager().isIslandWorld(loc);} catch (Exception e) {
+		try {return IslandManager.isIslandWorld(loc);} catch (Exception e) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Didn't really see what most of this did i just did the fixes for the latest Iridium API changes, I didn't notice any abnormal behavior due to these API updates or errors spew on my console, I did a normal void death drop in Overworld works well but when dropping into the nether void it stops a y0 and sits there; no errors from TempFly on that issue anymore so I think that void teleport issue is a Iridium issue 

This PR directly fixes #26 for the **latest Iridium Skyblock Only!** This obviously wont work on any version of Iridium Skyblock lower than ~2.6.7 (I cant pinpoint the exact version the updated the API in)