### PR TITLE
Update dbsetup.sql

### DIFF
--- a/TempFly/resources/dbsetup.sql
+++ b/TempFly/resources/dbsetup.sql
@@ -1,5 +1,5 @@
 
-CREATE TABLE IF NOT EXISTS TEMPFLY_DATA
+CREATE TABLE IF NOT EXISTS tempfly_data
 (
     uuid                    CHAR(36)                       NOT NULL,
     player_time             DOUBLE(10, 2)    DEFAULT 0,


### PR DESCRIPTION
On linux the mariadb server is case sensitive at default. This change prevents the following error in console: `java.sql.SQLSyntaxErrorException: Table 's2_TempFly.tempfly_data' doesn't exist`