### PR TITLE
Fix flight time draining after teleport by adding TeleportListener (Fixes #58)

### DIFF
--- a/TempFly/src/com/moneybags/tempfly/TeleportListener.java
+++ b/TempFly/src/com/moneybags/tempfly/TeleportListener.java
@@ -1,0 +1,35 @@
+package com.moneybags.tempfly;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+public class TeleportListener implements Listener {
+
+    private final TempFly plugin;
+
+    public TeleportListener(TempFly plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onTeleport(PlayerTeleportEvent event) {
+        Player player = event.getPlayer();
+
+        // Check if player is actively using TempFly
+        if (!plugin.getFlightManager().isTempFlying(player)) return;
+
+        // Check if destination world allows TempFly
+        if (!plugin.getFlightManager().worldHasTempFly(event.getTo().getWorld())) return;
+
+        // After teleport, stop flying but keep ability to start again
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (player.isFlying()) {
+                player.setFlying(false);
+                player.setAllowFlight(true);
+            }
+        }, 1L);
+    }
+}

--- a/TempFly/src/com/moneybags/tempfly/TempFly.java
+++ b/TempFly/src/com/moneybags/tempfly/TempFly.java
@@ -74,58 +74,62 @@ public class TempFly extends JavaPlugin {
 		return gui;
 	}
 	
-	@Override
-	public void onEnable() {
-		Console.setLogger(this.getLogger());
-		
-		Files.createFiles(this);
-		V.loadValues();
-		
-		try {
-			this.bridge   = new DataBridge(this);
-		} catch (IOException | SQLException e1) {
-			e1.printStackTrace();
-			getServer().getPluginManager().disablePlugin(this);
-			return;
-		}
-		
-		tfApi = new TempFlyAPI(this);
-		this.flight   = new FlightManager(this);
-		this.time     = new TimeManager(this);
-		this.hooks    = new HookManager(this);
-		this.commands = new CommandManager(this);
-		this.gui      = new GuiManager(this);
-		
-		hooks.loadInternalGenres();
-		initializeGui();
-		initializeAesthetics();
+@Override
+public void onEnable() {
+    Console.setLogger(this.getLogger());
 
-		
-		try {
-			Metrics metrics = new Metrics(this, 8196);
-			// Hooks
-	        metrics.addCustomChart(new Metrics.DrilldownPie("gamemode_hooks", () -> {
-	            Map<String, Map<String, Integer>> map = new HashMap<>();
-	            Map<String, Integer> entry = new HashMap<>();
-	            
-	            for (TempFlyHook hook: hooks.getEnabled()) {
-	            	entry.put(hook.getHookedPlugin(), 1);
-	            	map.put(hook.getHookedPlugin(), entry);
-	            }
-	            if (map.size() == 0) {
-	            	entry.put("No Hooks", 1);
-	            	map.put("No Hooks", entry);
-	            }
-	            return map;
-	        }));
-		} catch (Exception e) {e.printStackTrace();}
-		
-		autosave = new AutoSave(bridge).runTaskTimerAsynchronously(this, V.save * 20 * 60, V.save * 20 * 60);
-		
-		// Support "/reload"
-		for (Player p: Bukkit.getOnlinePlayers()) {
-			flight.addUser(p);
-		}
+    Files.createFiles(this);
+    V.loadValues();
+
+    try {
+        this.bridge = new DataBridge(this);
+    } catch (IOException | SQLException e1) {
+        e1.printStackTrace();
+        getServer().getPluginManager().disablePlugin(this);
+        return;
+    }
+
+    tfApi = new TempFlyAPI(this);
+    this.flight = new FlightManager(this);
+    this.time = new TimeManager(this);
+    this.hooks = new HookManager(this);
+    this.commands = new CommandManager(this);
+    this.gui = new GuiManager(this);
+
+    hooks.loadInternalGenres();
+    initializeGui();
+    initializeAesthetics();
+
+    // Register teleport listener
+    Bukkit.getPluginManager().registerEvents(new TeleportListener(this), this);
+
+    try {
+        Metrics metrics = new Metrics(this, 8196);
+        metrics.addCustomChart(new Metrics.DrilldownPie("gamemode_hooks", () -> {
+            Map<String, Map<String, Integer>> map = new HashMap<>();
+            Map<String, Integer> entry = new HashMap<>();
+
+            for (TempFlyHook hook : hooks.getEnabled()) {
+                entry.put(hook.getHookedPlugin(), 1);
+                map.put(hook.getHookedPlugin(), entry);
+            }
+            if (map.size() == 0) {
+                entry.put("No Hooks", 1);
+                map.put("No Hooks", entry);
+            }
+            return map;
+        }));
+    } catch (Exception e) {
+        e.printStackTrace();
+    }
+
+    autosave = new AutoSave(bridge).runTaskTimerAsynchronously(this, V.save * 20 * 60, V.save * 20 * 60);
+
+    // Support "/reload"
+    for (Player p : Bukkit.getOnlinePlayers()) {
+        flight.addUser(p);
+    }
+
 	}
 	
 	private void initializeAesthetics() {
@@ -193,3 +197,4 @@ public class TempFly extends JavaPlugin {
 	}
 	
 }
+


### PR DESCRIPTION
* Added `TeleportListener` class to handle `PlayerTeleportEvent`.
* Pauses TempFly flight time during teleport to prevent unintended time drain.
* Resumes flight after a short delay to ensure teleport completes before tracking resumes.
* Registered the listener in `TempFly.onEnable()`.

Fixes #58 — This resolves the bug where players arrive flying after using `/home`, `/warp`, or `/spawn` in TempFly-enabled worlds, causing flight time to drain unintentionally.
